### PR TITLE
Update bro-pkg.meta

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -1,2 +1,5 @@
 [package]
-version = 1.0.0
+description = Adds support for multi-notice correlation.
+  For more information, see http://blog.samoehlert.com/correlating-bro-notices
+  or the talk from BroCon 2016.
+tags = notices, notice, correlation


### PR DESCRIPTION
In the near future, bro-pkg will expect to find all package metadata in bro-pkg.meta instead of having tags/description fields maintained separately in package source's bro-pkg.index.

The version field can be removed.  Instead, use git tags for versioning (optional).  More info on versioning here:

http://bro-package-manager.readthedocs.io/en/latest/package.html#package-versioning